### PR TITLE
Rxjs fix

### DIFF
--- a/nuclide/nuclide-adb/lib/Adb.js
+++ b/nuclide/nuclide-adb/lib/Adb.js
@@ -19,7 +19,7 @@ import type {NuclideUri} from '@atom-ide-community/nuclide-commons/nuclideUri';
 
 import invariant from 'assert';
 import nuclideUri from '@atom-ide-community/nuclide-commons/nuclideUri';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import {parsePsTableOutput} from './common/ps';
 import {runCommand, observeProcess} from '@atom-ide-community/nuclide-commons/process';
 

--- a/nuclide/nuclide-adb/lib/AdbDevicePoller.js
+++ b/nuclide/nuclide-adb/lib/AdbDevicePoller.js
@@ -18,7 +18,7 @@ import {getLogger} from 'log4js';
 import {arrayEqual} from '@atom-ide-community/nuclide-commons/collection';
 import {SimpleCache} from '@atom-ide-community/nuclide-commons/SimpleCache';
 import shallowEqual from 'shallowequal';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import {Expect, expectedEqual} from '@atom-ide-community/nuclide-commons/expected';
 import nuclideUri from '@atom-ide-community/nuclide-commons/nuclideUri';
 import {track} from '@atom-ide-community/nuclide-commons/analytics';

--- a/nuclide/nuclide-adb/lib/AdbService.js
+++ b/nuclide/nuclide-adb/lib/AdbService.js
@@ -19,7 +19,7 @@ import type {AdbDevice, AndroidJavaProcess, Process} from './types';
 
 import fsPromise from '@atom-ide-community/nuclide-commons/fsPromise';
 import nuclideUri from '@atom-ide-community/nuclide-commons/nuclideUri';
-import {ConnectableObservable} from 'rxjs';
+import {ConnectableObservable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import {Adb} from './Adb';
 import {Processes} from './common/Processes';
 import {runCommand} from '@atom-ide-community/nuclide-commons/process';

--- a/nuclide/nuclide-adb/lib/Tunneling.js
+++ b/nuclide/nuclide-adb/lib/Tunneling.js
@@ -12,14 +12,14 @@
 
 import type {SshTunnelService} from '@atom-ide-community/nuclide-adb/lib/types';
 import type {NuclideUri} from '@atom-ide-community/nuclide-commons/nuclideUri';
-import type {Subscription} from 'rxjs';
+import type {Subscription} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 import invariant from 'assert';
 import {shell} from 'electron';
 import {getLogger} from 'log4js';
 import {SimpleCache} from '@atom-ide-community/nuclide-commons/SimpleCache';
 import nuclideUri from '@atom-ide-community/nuclide-commons/nuclideUri';
-import {Observable, Subject} from 'rxjs';
+import {Observable, Subject} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import consumeFirstProvider from '@atom-ide-community/nuclide-commons-atom/consumeFirstProvider';
 import {getAdbServiceByNuclideUri} from './utils';
 import {track} from '@atom-ide-community/nuclide-commons/analytics';

--- a/nuclide/nuclide-adb/lib/common/Processes.js
+++ b/nuclide/nuclide-adb/lib/common/Processes.js
@@ -14,7 +14,7 @@ import type {Adb} from '../Adb';
 import type {Process} from '../types';
 
 import {arrayCompact} from '@atom-ide-community/nuclide-commons/collection';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import os from 'os';
 
 type CPU_MEM = [number, number];

--- a/nuclide/nuclide-adb/lib/types.js
+++ b/nuclide/nuclide-adb/lib/types.js
@@ -11,7 +11,7 @@
  */
 
 import type {NuclideUri} from '@atom-ide-community/nuclide-commons/nuclideUri';
-import type {Observable} from 'rxjs';
+import type {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import type Immutable from 'immutable';
 
 export type SimpleProcess = {

--- a/nuclide/nuclide-adb/package.json
+++ b/nuclide/nuclide-adb/package.json
@@ -28,7 +28,7 @@
     "@atom-ide-community/nuclide-commons": "workspace:*",
     "@atom-ide-community/nuclide-commons-atom": "workspace:*",
     "nullthrows": "1.1.1",
-    "rxjs": "npm:rxjs-compat@6.3.3",
+    "rxjs-compat": "^6.3.3",
     "shallowequal": "1.1.0"
   }
 }

--- a/nuclide/nuclide-analytics/__atom_tests__/track-test.js
+++ b/nuclide/nuclide-analytics/__atom_tests__/track-test.js
@@ -25,7 +25,7 @@ import {
 } from '@atom-ide-community/nuclide-commons/analytics';
 import service from '../lib/track';
 import invariant from 'assert';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 const sleep = n => new Promise(r => setTimeout(r, n));
 

--- a/nuclide/nuclide-analytics/lib/analytics.js
+++ b/nuclide/nuclide-analytics/lib/analytics.js
@@ -11,7 +11,7 @@
  */
 
 import type {SessionInfo} from '@atom-ide-community/nuclide-commons/analytics';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 // This is a stubbed implementation that other packages use to record analytics data & performance.
 export function track(

--- a/nuclide/nuclide-commons-atom/ActiveEditorRegistry.js
+++ b/nuclide/nuclide-commons-atom/ActiveEditorRegistry.js
@@ -15,7 +15,7 @@
  * on text editor contents.
  */
 
-import {Observable, Subject} from 'rxjs';
+import {Observable, Subject} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import {observeActiveEditorsDebounced} from './debounced';
 import UniversalDisposable from '@atom-ide-community/nuclide-commons/UniversalDisposable';
 import {observableFromSubscribeFunction} from '@atom-ide-community/nuclide-commons/event';

--- a/nuclide/nuclide-commons-atom/ConfigManager.js
+++ b/nuclide/nuclide-commons-atom/ConfigManager.js
@@ -11,7 +11,7 @@
  */
 
 import invariant from 'assert';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 /**
  * A wrapper over the specified Atom's config functions.

--- a/nuclide/nuclide-commons-atom/FeatureLoader.js
+++ b/nuclide/nuclide-commons-atom/FeatureLoader.js
@@ -22,7 +22,7 @@ import nuclideConfig from './nuclide-config';
 import featureConfig from './feature-config';
 import path from 'path'; // eslint-disable-line nuclide-internal/prefer-nuclide-uri
 import {MultiMap, setIntersect, setUnion} from '@atom-ide-community/nuclide-commons/collection';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 type FeaturePkg = {
   name: string,

--- a/nuclide/nuclide-commons-atom/FileEventHandlers.js
+++ b/nuclide/nuclide-commons-atom/FileEventHandlers.js
@@ -13,7 +13,7 @@
 import type {Provider} from './ProviderRegistry';
 import type {TextEdit} from './text-edit';
 
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import {track} from '@atom-ide-community/nuclide-commons/analytics';
 import ProviderRegistry from './ProviderRegistry';
 import {applyTextEditsToBuffer} from './text-edit';

--- a/nuclide/nuclide-commons-atom/__atom_tests__/ActiveEditorRegistry-test.js
+++ b/nuclide/nuclide-commons-atom/__atom_tests__/ActiveEditorRegistry-test.js
@@ -16,10 +16,10 @@ import type {
   Result,
 } from '../ActiveEditorRegistry';
 
-import type {Observable} from 'rxjs';
+import type {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 import {expectObservableToStartWith} from '@atom-ide-community/nuclide-commons/test-helpers';
-import {Subject} from 'rxjs';
+import {Subject} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 import ActiveEditorRegistry from '../ActiveEditorRegistry';
 

--- a/nuclide/nuclide-commons-atom/__atom_tests__/debounced-test.js
+++ b/nuclide/nuclide-commons-atom/__atom_tests__/debounced-test.js
@@ -11,7 +11,7 @@
  * @emails oncall+nuclide
  */
 import {Point} from 'atom';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import {
   editorScrollTopDebounced,
   observeActivePaneItemDebounced,

--- a/nuclide/nuclide-commons-atom/debounced.js
+++ b/nuclide/nuclide-commons-atom/debounced.js
@@ -20,7 +20,7 @@
  */
 
 import {fastDebounce} from '@atom-ide-community/nuclide-commons/observable';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 import {observableFromSubscribeFunction} from '@atom-ide-community/nuclide-commons/event';
 import {getCursorPositions, isValidTextEditor} from './text-editor';

--- a/nuclide/nuclide-commons-atom/experimental-packages/MessageRouter.js
+++ b/nuclide/nuclide-commons-atom/experimental-packages/MessageRouter.js
@@ -14,7 +14,7 @@ import type {PipedMessage, ServiceConnection} from './types';
 
 import {getLogger} from 'log4js';
 import {DefaultMap} from '@atom-ide-community/nuclide-commons/collection';
-import {Observable, Subject} from 'rxjs';
+import {Observable, Subject} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import * as jsonrpc from 'vscode-jsonrpc';
 import {AbstractMessageReader} from 'vscode-jsonrpc/lib/messageReader';
 import {AbstractMessageWriter} from 'vscode-jsonrpc/lib/messageWriter';

--- a/nuclide/nuclide-commons-atom/experimental-packages/PackageRunners.js
+++ b/nuclide/nuclide-commons-atom/experimental-packages/PackageRunners.js
@@ -11,7 +11,7 @@
  */
 
 import type {ProcessMessage} from '@atom-ide-community/nuclide-commons/process';
-import type {ConnectableObservable} from 'rxjs';
+import type {ConnectableObservable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import type {
   InitializeMessage,
   PackageParams,
@@ -21,7 +21,7 @@ import type {
 
 import {fork, getOutputStream} from '@atom-ide-community/nuclide-commons/process';
 import UniversalDisposable from '@atom-ide-community/nuclide-commons/UniversalDisposable';
-import {ReplaySubject} from 'rxjs';
+import {ReplaySubject} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import MessageRouter from './MessageRouter';
 import activatePackage from './activatePackage';
 

--- a/nuclide/nuclide-commons-atom/go-to-location.js
+++ b/nuclide/nuclide-commons-atom/go-to-location.js
@@ -10,10 +10,10 @@
  * @format
  */
 
-import type {Observable} from 'rxjs';
+import type {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 import {getLogger} from 'log4js';
-import {Subject} from 'rxjs';
+import {Subject} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import invariant from 'assert';
 
 export type GoToLocationOptions = {|

--- a/nuclide/nuclide-commons-atom/observePaneItemVisibility.js
+++ b/nuclide/nuclide-commons-atom/observePaneItemVisibility.js
@@ -13,7 +13,7 @@
 import {observableFromSubscribeFunction} from '@atom-ide-community/nuclide-commons/event';
 import memoizeUntilChanged from '@atom-ide-community/nuclide-commons/memoizeUntilChanged';
 import {setFilter} from '@atom-ide-community/nuclide-commons/collection';
-import {Observable, Scheduler, Subject} from 'rxjs';
+import {Observable, Scheduler, Subject} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import shallowEqual from 'shallowequal';
 
 // TODO(T17495608): Currently, docks don't have a way of observing their visibility so this will

--- a/nuclide/nuclide-commons-atom/package.json
+++ b/nuclide/nuclide-commons-atom/package.json
@@ -20,7 +20,7 @@
     "@atom-ide-community/nuclide-commons": "workspace:*",
     "nullthrows": "1.1.1",
     "redux-logger": "3.0.6",
-    "rxjs": "npm:rxjs-compat@6.3.3",
+    "rxjs-compat": "^6.3.3",
     "season": "6.0.2",
     "semver": "5.5.0",
     "shallowequal": "1.1.0",

--- a/nuclide/nuclide-commons-atom/projects.js
+++ b/nuclide/nuclide-commons-atom/projects.js
@@ -16,7 +16,7 @@ import {File, Directory} from 'atom';
 import {observableFromSubscribeFunction} from '@atom-ide-community/nuclide-commons/event';
 import nuclideUri from '@atom-ide-community/nuclide-commons/nuclideUri';
 import {diffSets} from '@atom-ide-community/nuclide-commons/observable';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 export function getValidProjectPaths(): Array<string> {
   return atom.project

--- a/nuclide/nuclide-commons-atom/text-editor.js
+++ b/nuclide/nuclide-commons-atom/text-editor.js
@@ -14,7 +14,7 @@ import type {NuclideUri} from '@atom-ide-community/nuclide-commons/nuclideUri';
 
 import invariant from 'assert';
 import {TextEditor} from 'atom';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 import {observableFromSubscribeFunction} from '@atom-ide-community/nuclide-commons/event';
 

--- a/nuclide/nuclide-commons-atom/text-event.js
+++ b/nuclide/nuclide-commons-atom/text-event.js
@@ -11,7 +11,7 @@
  */
 
 import invariant from 'assert';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import debounce from '@atom-ide-community/nuclide-commons/debounce';
 import {observableFromSubscribeFunction} from '@atom-ide-community/nuclide-commons/event';
 import UniversalDisposable from '@atom-ide-community/nuclide-commons/UniversalDisposable';

--- a/nuclide/nuclide-commons-ui/AtomTextEditor.js
+++ b/nuclide/nuclide-commons-ui/AtomTextEditor.js
@@ -19,7 +19,7 @@ import {
   enforceSoftWrap,
 } from '@atom-ide-community/nuclide-commons-atom/text-editor';
 import UniversalDisposable from '@atom-ide-community/nuclide-commons/UniversalDisposable';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import atomTabIndexForwarder from './atomTabIndexForwarder';
 
 const doNothing = () => {};

--- a/nuclide/nuclide-commons-ui/DateSelector.js
+++ b/nuclide/nuclide-commons-ui/DateSelector.js
@@ -13,7 +13,7 @@
 /* global Node */
 
 import classnames from 'classnames';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import UniversalDisposable from '@atom-ide-community/nuclide-commons/UniversalDisposable';
 import * as React from 'react';
 import {DateRangePicker} from 'tiny-date-picker/dist/date-range-picker';

--- a/nuclide/nuclide-commons-ui/DragResizeContainer.js
+++ b/nuclide/nuclide-commons-ui/DragResizeContainer.js
@@ -11,7 +11,7 @@
  */
 
 import * as React from 'react';
-import {Observable, Subject} from 'rxjs';
+import {Observable, Subject} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import nullthrows from 'nullthrows';
 import UniversalDisposable from '@atom-ide-community/nuclide-commons/UniversalDisposable';
 

--- a/nuclide/nuclide-commons-ui/DraggableFile.js
+++ b/nuclide/nuclide-commons-ui/DraggableFile.js
@@ -14,7 +14,7 @@ import type {NuclideUri} from '@atom-ide-community/nuclide-commons/nuclideUri';
 import UniversalDisposable from '@atom-ide-community/nuclide-commons/UniversalDisposable';
 import * as React from 'react';
 import ReactDOM from 'react-dom';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import {track} from '@atom-ide-community/nuclide-commons/analytics';
 
 const MAGIC_DATA_TRANSFER_KEY = 'nuclide-draggable-file';

--- a/nuclide/nuclide-commons-ui/Modal.js
+++ b/nuclide/nuclide-commons-ui/Modal.js
@@ -15,7 +15,7 @@
 import UniversalDisposable from '@atom-ide-community/nuclide-commons/UniversalDisposable';
 import * as React from 'react';
 import ReactDOM from 'react-dom';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 type Props = {
   children?: any,

--- a/nuclide/nuclide-commons-ui/ResizeSensitiveContainer.js
+++ b/nuclide/nuclide-commons-ui/ResizeSensitiveContainer.js
@@ -14,7 +14,7 @@ import * as React from 'react';
 import classnames from 'classnames';
 import nullthrows from 'nullthrows';
 import {nextAnimationFrame} from '@atom-ide-community/nuclide-commons/observable';
-import {Subject} from 'rxjs';
+import {Subject} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 type SensorProps = {
   targetHeight: number,

--- a/nuclide/nuclide-commons-ui/SelectableTree.js
+++ b/nuclide/nuclide-commons-ui/SelectableTree.js
@@ -17,7 +17,7 @@ import UniversalDisposable from '@atom-ide-community/nuclide-commons/UniversalDi
 import * as React from 'react';
 import classnames from 'classnames';
 import invariant from 'assert';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import shallowEqual from 'shallowequal';
 import nullthrows from 'nullthrows';
 import {scrollIntoView} from './scrollIntoView';

--- a/nuclide/nuclide-commons-ui/TabbableContainer.js
+++ b/nuclide/nuclide-commons-ui/TabbableContainer.js
@@ -14,7 +14,7 @@
 
 import React from 'react';
 import invariant from 'assert';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import tabbable from 'tabbable';
 import classnames from 'classnames';
 import UniversalDisposable from '@atom-ide-community/nuclide-commons/UniversalDisposable';

--- a/nuclide/nuclide-commons-ui/Table.js
+++ b/nuclide/nuclide-commons-ui/Table.js
@@ -14,7 +14,7 @@ import invariant from 'assert';
 import nullthrows from 'nullthrows';
 import classnames from 'classnames';
 import * as React from 'react';
-import {Observable, Subject} from 'rxjs';
+import {Observable, Subject} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import shallowEqual from 'shallowequal';
 import {Icon} from './Icon';
 import {

--- a/nuclide/nuclide-commons-ui/__atom_tests__/observable-dom-test.js
+++ b/nuclide/nuclide-commons-ui/__atom_tests__/observable-dom-test.js
@@ -11,7 +11,7 @@
  * @emails oncall+nuclide
  */
 import invariant from 'assert';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 import {_DOMObserverObservable as DOMObserverObservable} from '../observable-dom';
 

--- a/nuclide/nuclide-commons-ui/bindObservableAsProps.js
+++ b/nuclide/nuclide-commons-ui/bindObservableAsProps.js
@@ -10,7 +10,7 @@
  * @format
  */
 
-import type {Observable} from 'rxjs';
+import type {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 import * as React from 'react';
 import getDisplayName from '@atom-ide-community/nuclide-commons/getDisplayName';

--- a/nuclide/nuclide-commons-ui/observable-dom.js
+++ b/nuclide/nuclide-commons-ui/observable-dom.js
@@ -15,7 +15,7 @@
 
 import invariant from 'assert';
 import os from 'os';
-import {Observable, Subscription} from 'rxjs';
+import {Observable, Subscription} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import shallowEqual from 'shallowequal';
 import {isIterable} from '@atom-ide-community/nuclide-commons/collection';
 

--- a/nuclide/nuclide-commons-ui/observeStalls.js
+++ b/nuclide/nuclide-commons-ui/observeStalls.js
@@ -15,7 +15,7 @@
 import invariant from 'assert';
 import getDisplayName from '@atom-ide-community/nuclide-commons/getDisplayName';
 import {remote} from 'electron';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import {PerformanceObservable} from './observable-dom';
 
 import UniversalDisposable from '@atom-ide-community/nuclide-commons/UniversalDisposable';

--- a/nuclide/nuclide-commons-ui/package.json
+++ b/nuclide/nuclide-commons-ui/package.json
@@ -29,7 +29,7 @@
     "react": "16.6.3",
     "react-dom": "16.6.3",
     "react-virtualized": "9.20.1",
-    "rxjs": "npm:rxjs-compat@6.3.3",
+    "rxjs-compat": "^6.3.3",
     "semver": "5.5.0",
     "shallowequal": "1.1.0",
     "tabbable": "1.1.0",

--- a/nuclide/nuclide-commons-ui/showModal.js
+++ b/nuclide/nuclide-commons-ui/showModal.js
@@ -16,7 +16,7 @@
 import invariant from 'assert';
 import * as React from 'react';
 import ReactDOM from 'react-dom';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import UniversalDisposable from '@atom-ide-community/nuclide-commons/UniversalDisposable';
 
 import TabbableContainer from './TabbableContainer';

--- a/nuclide/nuclide-commons/Model.js
+++ b/nuclide/nuclide-commons/Model.js
@@ -10,9 +10,9 @@
  * @format
  */
 
-import type {Observable} from 'rxjs';
+import type {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
-import {BehaviorSubject} from 'rxjs';
+import {BehaviorSubject} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import UniversalDisposable from './UniversalDisposable';
 
 /**

--- a/nuclide/nuclide-commons/ObservablePool.js
+++ b/nuclide/nuclide-commons/ObservablePool.js
@@ -10,7 +10,7 @@
  * @format
  */
 
-import {Observable, Subject} from 'rxjs';
+import {Observable, Subject} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 type Executor<T> = Observable<T> | (() => rxjs$ObservableInput<T>);
 

--- a/nuclide/nuclide-commons/__tests__/ObservablePool-test.js
+++ b/nuclide/nuclide-commons/__tests__/ObservablePool-test.js
@@ -11,7 +11,7 @@
  * @emails oncall+nuclide
  */
 import invariant from 'assert';
-import {Observable, Subject} from 'rxjs';
+import {Observable, Subject} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import ObservablePool from '../ObservablePool';
 import waitsFor from '../../atom-test-runners/jest-atom-runner/configs/waits_for';
 

--- a/nuclide/nuclide-commons/__tests__/nice-test.js
+++ b/nuclide/nuclide-commons/__tests__/nice-test.js
@@ -13,7 +13,7 @@
 import typeof {niceSafeSpawn as niceSafeSpawnType} from '../nice';
 
 import {uncachedRequire} from '../test-helpers';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 describe('nice', () => {
   let niceSafeSpawn: niceSafeSpawnType = (null: any);

--- a/nuclide/nuclide-commons/__tests__/observable-test.js
+++ b/nuclide/nuclide-commons/__tests__/observable-test.js
@@ -36,7 +36,7 @@ import {
 import nullthrows from 'nullthrows';
 import AbortController from '../AbortController';
 import UniversalDisposable from '../UniversalDisposable';
-import {Observable, Subject} from 'rxjs';
+import {Observable, Subject} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 const setsAreEqual = (a, b) =>
   a.size === b.size && Array.from(a).every(b.has.bind(b));

--- a/nuclide/nuclide-commons/__tests__/process-test.js
+++ b/nuclide/nuclide-commons/__tests__/process-test.js
@@ -17,7 +17,7 @@ import {getLogger} from 'log4js';
 import {sleep} from '../promise';
 import child_process from 'child_process';
 import invariant from 'assert';
-import {Observable, Scheduler, Subject} from 'rxjs';
+import {Observable, Scheduler, Subject} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 import {
   spawn,

--- a/nuclide/nuclide-commons/__tests__/throttle-test.js
+++ b/nuclide/nuclide-commons/__tests__/throttle-test.js
@@ -11,7 +11,7 @@
  * @emails oncall+nuclide
  */
 import {throttle} from '../observable.js';
-import {Subject, Observable} from 'rxjs';
+import {Subject, Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import {sleep} from '../promise';
 import retry from 'jest-retries';
 

--- a/nuclide/nuclide-commons/__tests__/which-test.js
+++ b/nuclide/nuclide-commons/__tests__/which-test.js
@@ -12,7 +12,7 @@
  * @emails oncall+nuclide
  */
 import which from '../which';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 describe('which', () => {
   let runCommand;

--- a/nuclide/nuclide-commons/analytics.js
+++ b/nuclide/nuclide-commons/analytics.js
@@ -10,7 +10,7 @@
  * @format
  */
 
-import type {Observable} from 'rxjs';
+import type {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 import getDisplayName from './getDisplayName';
 import UniversalDisposable from './UniversalDisposable';

--- a/nuclide/nuclide-commons/cache.js
+++ b/nuclide/nuclide-commons/cache.js
@@ -10,7 +10,7 @@
  * @format
  */
 
-import {Observable, Subject} from 'rxjs';
+import {Observable, Subject} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 // A Cache mapping keys to values which creates entries as they are requested.
 export class Cache<KeyType, ValueType> {

--- a/nuclide/nuclide-commons/event.js
+++ b/nuclide/nuclide-commons/event.js
@@ -11,7 +11,7 @@
  */
 
 import UniversalDisposable from './UniversalDisposable';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 /**
  * Add an event listener an return a disposable for removing it. Note that this function assumes

--- a/nuclide/nuclide-commons/nice.js
+++ b/nuclide/nuclide-commons/nice.js
@@ -14,7 +14,7 @@ import type {LRUCache} from 'lru-cache';
 import type {ObserveProcessOptions, ProcessMessage} from './process';
 
 import LRU from 'lru-cache';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 import which from './which';
 import {spawn, observeProcess} from './process';

--- a/nuclide/nuclide-commons/observable.js
+++ b/nuclide/nuclide-commons/observable.js
@@ -30,7 +30,7 @@ import UniversalDisposable from './UniversalDisposable';
 import invariant from 'assert';
 // Note: DOMException is usable in Chrome but not in Node.
 import DOMException from 'domexception';
-import {Observable, ReplaySubject, Subject, Subscription} from 'rxjs';
+import {Observable, ReplaySubject, Subject, Subscription} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import AbortController from './AbortController';
 import {setDifference} from './collection';
 import debounce from './debounce';

--- a/nuclide/nuclide-commons/observableFromReduxStore.js
+++ b/nuclide/nuclide-commons/observableFromReduxStore.js
@@ -10,7 +10,7 @@
  * @format
  */
 
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import {observableFromSubscribeFunction} from './event';
 
 type Store<S> = {

--- a/nuclide/nuclide-commons/package.json
+++ b/nuclide/nuclide-commons/package.json
@@ -27,7 +27,7 @@
     "mv": "2.1.1",
     "nullthrows": "1.1.1",
     "rimraf": "3.0.2",
-    "rxjs": "npm:rxjs-compat@6.3.3",
+    "rxjs-compat": "^6.3.3",
     "semver": "5.5.0",
     "shell-quote": "1.6.1",
     "temp": "0.9.1",

--- a/nuclide/nuclide-commons/process.js
+++ b/nuclide/nuclide-commons/process.js
@@ -52,7 +52,7 @@ import child_process from 'child_process';
 import idx from 'idx';
 import {getLogger} from 'log4js';
 import invariant from 'assert';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import util from 'util';
 
 import UniversalDisposable from './UniversalDisposable';

--- a/nuclide/nuclide-commons/redux-observable.js
+++ b/nuclide/nuclide-commons/redux-observable.js
@@ -35,7 +35,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import {Observable, Subject} from 'rxjs';
+import {Observable, Subject} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 // This should be { type: readonly string } when we get readonly props. Because this is used with
 // disjoint unions we can't use `string` here due to mutation concerns. Flow doesn't know that we

--- a/nuclide/nuclide-commons/stream.js
+++ b/nuclide/nuclide-commons/stream.js
@@ -11,7 +11,7 @@
  */
 
 import Stream from 'stream';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 import UniversalDisposable from './UniversalDisposable';
 import {attachEvent} from './event';

--- a/nuclide/nuclide-commons/test-helpers.js
+++ b/nuclide/nuclide-commons/test-helpers.js
@@ -10,7 +10,7 @@
  * @format
  */
 
-import type {Observable} from 'rxjs';
+import type {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 import invariant from 'assert';
 import fs from 'fs';

--- a/nuclide/nuclide-debugger-cli/lib/CommandLine.js
+++ b/nuclide/nuclide-debugger-cli/lib/CommandLine.js
@@ -17,7 +17,7 @@ import {analytics} from './analytics';
 import CommandDispatcher from './CommandDispatcher';
 import ConfigFile from './ConfigFile';
 import LineEditor from './console/LineEditor';
-import {Observable, Subject} from 'rxjs';
+import {Observable, Subject} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 const PROMPT = 'fbdbg> ';
 

--- a/nuclide/nuclide-debugger-cli/lib/ConsoleIO.js
+++ b/nuclide/nuclide-debugger-cli/lib/ConsoleIO.js
@@ -11,7 +11,7 @@
  */
 import type {Completions} from './console/LineEditor';
 
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 export interface ConsoleIO {
   enterFullScreen(): void;

--- a/nuclide/nuclide-debugger-cli/lib/EnterCodeCommand.js
+++ b/nuclide/nuclide-debugger-cli/lib/EnterCodeCommand.js
@@ -14,7 +14,7 @@ import type {Command} from './Command';
 import type {ConsoleIO} from './ConsoleIO';
 
 import {DebuggerInterface} from './DebuggerInterface';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 type InterruptEvent = {
   type: 'interrupt',

--- a/nuclide/nuclide-debugger-cli/lib/OptoutCommand.js
+++ b/nuclide/nuclide-debugger-cli/lib/OptoutCommand.js
@@ -14,7 +14,7 @@ import type {Command} from './Command';
 import type {ConsoleIO} from './ConsoleIO';
 
 import os from 'os';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import {trackImmediate} from '@atom-ide-community/nuclide-commons/analytics';
 
 type InterruptEvent = {

--- a/nuclide/nuclide-debugger-cli/lib/adapters/NativeGdbDebugAdapter.js
+++ b/nuclide/nuclide-debugger-cli/lib/adapters/NativeGdbDebugAdapter.js
@@ -24,7 +24,7 @@ import {getAdapterPackageRoot} from '@atom-ide-community/nuclide-debugger-common
 import {runCommand} from '@atom-ide-community/nuclide-commons/process';
 import nuclideUri from '@atom-ide-community/nuclide-commons/nuclideUri';
 import {VsAdapterTypes} from '@atom-ide-community/nuclide-debugger-common/constants';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import VSPOptionsParser from '../VSPOptionsParser';
 
 export default class NativeGdbDebugAdapter implements DebugAdapter {

--- a/nuclide/nuclide-debugger-cli/lib/console/CompletionDialog.js
+++ b/nuclide/nuclide-debugger-cli/lib/console/CompletionDialog.js
@@ -11,7 +11,7 @@
  */
 import type {ElementOptions, Keypress} from 'blessed';
 import * as DebugProtocol from 'vscode-debugprotocol';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 // $FlowFixMe - make UniversalDisposable flow strict
 import UniversalDisposable from '@atom-ide-community/nuclide-commons/UniversalDisposable';
 

--- a/nuclide/nuclide-debugger-cli/lib/main.js
+++ b/nuclide/nuclide-debugger-cli/lib/main.js
@@ -27,7 +27,7 @@ import QuitCommand from './QuitCommand';
 import yargs from 'yargs';
 import {setRawAnalyticsService} from '@atom-ide-community/nuclide-commons/analytics';
 import * as rawAnalyticsService from '@atom-ide-community/nuclide-analytics/lib/track';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 function buildLogger(): log4js$Logger {
   // there are things in nuclide while will still try to log to

--- a/nuclide/nuclide-debugger-cli/package.json
+++ b/nuclide/nuclide-debugger-cli/package.json
@@ -21,7 +21,7 @@
     "@atom-ide-community/nuclide-commons": "workspace:*",
     "@atom-ide-community/nuclide-debugger-common": "workspace:*",
     "nullthrows": "1.1.1",
-    "rxjs": "npm:rxjs-compat@6.3.3",
+    "rxjs-compat": "^6.3.3",
     "v8-compile-cache": "1.1.0",
     "vscode-debugprotocol": "1.24.0",
     "yargs": "3.32.0"

--- a/nuclide/nuclide-debugger-common/DeviceAndProcess.js
+++ b/nuclide/nuclide-debugger-common/DeviceAndProcess.js
@@ -14,7 +14,7 @@ import type {AdbDevice, AndroidJavaProcess} from '@atom-ide-community/nuclide-ad
 import type {Column, Row} from '@atom-ide-community/nuclide-commons-ui/Table';
 import type {Expected} from '@atom-ide-community/nuclide-commons/expected';
 import type {NuclideUri} from '@atom-ide-community/nuclide-commons/nuclideUri';
-import type {Subscription} from 'rxjs';
+import type {Subscription} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 import idx from 'idx';
 import {getAdbServiceByNuclideUri} from '@atom-ide-community/nuclide-adb';
@@ -25,7 +25,7 @@ import {arrayEqual} from '@atom-ide-community/nuclide-commons/collection';
 import {Expect} from '@atom-ide-community/nuclide-commons/expected';
 import UniversalDisposable from '@atom-ide-community/nuclide-commons/UniversalDisposable';
 import * as React from 'react';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import {AdbDeviceSelector} from './AdbDeviceSelector';
 
 type ColumnName = 'pid' | 'user' | 'name';

--- a/nuclide/nuclide-debugger-common/SelectableFilterableProcessTable.js
+++ b/nuclide/nuclide-debugger-common/SelectableFilterableProcessTable.js
@@ -20,7 +20,7 @@ import {AtomInput} from '@atom-ide-community/nuclide-commons-ui/AtomInput';
 import {Table} from '@atom-ide-community/nuclide-commons-ui/Table';
 import nuclideUri from '@atom-ide-community/nuclide-commons/nuclideUri';
 import UniversalDisposable from '@atom-ide-community/nuclide-commons/UniversalDisposable';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 const PROCESS_UPDATES_INTERVAL_MS = 2000;
 

--- a/nuclide/nuclide-debugger-common/VSCodeDebuggerAdapterService.js
+++ b/nuclide/nuclide-debugger-common/VSCodeDebuggerAdapterService.js
@@ -10,7 +10,7 @@
  * @format
  */
 
-import type {ConnectableObservable} from 'rxjs';
+import type {ConnectableObservable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import type {VSAdapterExecutableInfo, VsAdapterType} from './types';
 import type {ProcessInfo, ProcessMessage} from '@atom-ide-community/nuclide-commons/process';
 

--- a/nuclide/nuclide-debugger-common/VsAdapterSpawner.js
+++ b/nuclide/nuclide-debugger-common/VsAdapterSpawner.js
@@ -10,7 +10,7 @@
  * @format
  */
 
-import type {ConnectableObservable} from 'rxjs';
+import type {ConnectableObservable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import type {ProcessMessage} from '@atom-ide-community/nuclide-commons/process';
 import type {VSAdapterExecutableInfo, IVsAdapterSpawner} from './types';
 
@@ -18,7 +18,7 @@ import {
   observeProcessRaw,
   getOriginalEnvironment,
 } from '@atom-ide-community/nuclide-commons/process';
-import {Observable, Subject} from 'rxjs';
+import {Observable, Subject} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 
 export default class VsAdapterSpawner implements IVsAdapterSpawner {
   _stdin: Subject<string>;

--- a/nuclide/nuclide-debugger-common/VsDebugSession.js
+++ b/nuclide/nuclide-debugger-common/VsDebugSession.js
@@ -20,7 +20,7 @@ import type {ProcessMessage} from '@atom-ide-community/nuclide-commons/process';
 
 import VsAdapterSpawner from './VsAdapterSpawner';
 import V8Protocol from './V8Protocol';
-import {Observable, Subject, TimeoutError} from 'rxjs';
+import {Observable, Subject, TimeoutError} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import idx from 'idx';
 import invariant from 'assert';
 import {track, trackTiming} from '@atom-ide-community/nuclide-commons/analytics';

--- a/nuclide/nuclide-debugger-common/package.json
+++ b/nuclide/nuclide-debugger-common/package.json
@@ -21,7 +21,7 @@
     "@atom-ide-community/nuclide-commons-ui": "workspace:*",
     "nullthrows": "1.1.1",
     "react": "16.6.3",
-    "rxjs": "npm:rxjs-compat@6.3.3",
+    "rxjs-compat": "^6.3.3",
     "uuid": "3.0.1",
     "vscode-debugprotocol": "1.24.0"
   }

--- a/nuclide/nuclide-debugger-common/types.js
+++ b/nuclide/nuclide-debugger-common/types.js
@@ -14,7 +14,7 @@ import type {SuggestedProjectPath} from 'atom-ide-debugger-java/types';
 import type {TaskEvent, ProcessMessage} from '@atom-ide-community/nuclide-commons/process';
 import type {Expected} from '@atom-ide-community/nuclide-commons/expected';
 import type DebuggerLaunchAttachProvider from './DebuggerLaunchAttachProvider';
-import type {Observable, ConnectableObservable} from 'rxjs';
+import type {Observable, ConnectableObservable} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import type {NuclideUri} from '@atom-ide-community/nuclide-commons/nuclideUri';
 import type {IconName} from '@atom-ide-community/nuclide-commons-ui/Icon';
 import * as DebugProtocol from 'vscode-debugprotocol';

--- a/nuclide/nuclide-watchman-helpers/lib/WatchmanClient.js
+++ b/nuclide/nuclide-watchman-helpers/lib/WatchmanClient.js
@@ -15,7 +15,7 @@ import watchman from 'fb-watchman';
 import {fastDebounce} from '@atom-ide-community/nuclide-commons/observable';
 import {serializeAsyncCall, sleep} from '@atom-ide-community/nuclide-commons/promise';
 import {maybeToString} from '@atom-ide-community/nuclide-commons/string';
-import {Observable, Subject} from 'rxjs';
+import {Observable, Subject} from 'rxjs-compat/bundles/rxjs-compat.umd.min.js';
 import {getWatchmanBinaryPath} from './path';
 import WatchmanSubscription from './WatchmanSubscription';
 import {getLogger} from 'log4js';

--- a/nuclide/nuclide-watchman-helpers/package.json
+++ b/nuclide/nuclide-watchman-helpers/package.json
@@ -19,7 +19,7 @@
     "event-kit": "2.2.0",
     "fb-watchman": "2.0.1",
     "log4js": "1.1.1",
-    "rxjs": "npm:rxjs-compat@6.3.3",
+    "rxjs-compat": "^6.3.3",
     "@atom-ide-community/nuclide-commons": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,14 +97,14 @@ importers:
       '@atom-ide-community/nuclide-commons-atom': 'link:../../nuclide/nuclide-commons-atom'
       log4js: 1.1.1
       nullthrows: 1.1.1
-      rxjs: /rxjs-compat/6.3.3
+      rxjs-compat: 6.3.3
       shallowequal: 1.1.0
     specifiers:
       '@atom-ide-community/nuclide-commons': 'workspace:*'
       '@atom-ide-community/nuclide-commons-atom': 'workspace:*'
       log4js: 1.1.1
       nullthrows: 1.1.1
-      rxjs: 'npm:rxjs-compat@6.3.3'
+      rxjs-compat: ^6.3.3
       shallowequal: 1.1.0
   dist-nuclide/nuclide-analytics:
     dependencies:
@@ -133,7 +133,7 @@ importers:
       mv: 2.1.1
       nullthrows: 1.1.1
       rimraf: 3.0.2
-      rxjs: /rxjs-compat/6.3.3
+      rxjs-compat: 6.3.3
       semver: 5.5.0
       shell-quote: 1.6.1
       temp: 0.9.1
@@ -165,7 +165,7 @@ importers:
       mv: 2.1.1
       nullthrows: 1.1.1
       rimraf: 3.0.2
-      rxjs: 'npm:rxjs-compat@6.3.3'
+      rxjs-compat: ^6.3.3
       semver: 5.5.0
       shell-quote: 1.6.1
       simple-text-buffer: 9.2.11
@@ -184,7 +184,7 @@ importers:
       lru-cache: 4.0.2
       nullthrows: 1.1.1
       redux-logger: 3.0.6
-      rxjs: /rxjs-compat/6.3.3
+      rxjs-compat: 6.3.3
       season: 6.0.2
       semver: 5.5.0
       shallowequal: 1.1.0
@@ -202,7 +202,7 @@ importers:
       lru-cache: 4.0.2
       nullthrows: 1.1.1
       redux-logger: 3.0.6
-      rxjs: 'npm:rxjs-compat@6.3.3'
+      rxjs-compat: ^6.3.3
       season: 6.0.2
       semver: 5.5.0
       shallowequal: 1.1.0
@@ -229,7 +229,7 @@ importers:
       react: 16.6.3
       react-dom: 16.6.3_react@16.6.3
       react-virtualized: 9.20.1_react-dom@16.6.3+react@16.6.3
-      rxjs: /rxjs-compat/6.3.3
+      rxjs-compat: 6.3.3
       semver: 5.5.0
       shallowequal: 1.1.0
       tabbable: 1.1.0
@@ -253,7 +253,7 @@ importers:
       react: 16.6.3
       react-dom: 16.6.3
       react-virtualized: 9.20.1
-      rxjs: 'npm:rxjs-compat@6.3.3'
+      rxjs-compat: ^6.3.3
       semver: 5.5.0
       shallowequal: 1.1.0
       tabbable: 1.1.0
@@ -269,7 +269,7 @@ importers:
       line-by-line: 0.1.6
       log4js: 1.1.1
       nullthrows: 1.1.1
-      rxjs: /rxjs-compat/6.3.3
+      rxjs-compat: 6.3.3
       v8-compile-cache: 1.1.0
       vscode-debugprotocol: 1.24.0
       yargs: 3.32.0
@@ -291,7 +291,7 @@ importers:
       line-by-line: 0.1.6
       log4js: 1.1.1
       nullthrows: 1.1.1
-      rxjs: 'npm:rxjs-compat@6.3.3'
+      rxjs-compat: ^6.3.3
       simple-text-buffer: 9.2.11
       v8-compile-cache: 1.1.0
       vscode-debugprotocol: 1.24.0
@@ -307,7 +307,7 @@ importers:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 16.6.3
-      rxjs: /rxjs-compat/6.3.3
+      rxjs-compat: 6.3.3
       uuid: 3.0.1
       vscode-debugprotocol: 1.24.0
     specifiers:
@@ -320,7 +320,7 @@ importers:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 16.6.3
-      rxjs: 'npm:rxjs-compat@6.3.3'
+      rxjs-compat: ^6.3.3
       uuid: 3.0.1
       vscode-debugprotocol: 1.24.0
   dist-nuclide/nuclide-fuzzy-native:
@@ -390,27 +390,27 @@ importers:
       event-kit: 2.2.0
       fb-watchman: 2.0.1
       log4js: 1.1.1
-      rxjs: /rxjs-compat/6.3.3
+      rxjs-compat: 6.3.3
     specifiers:
       '@atom-ide-community/nuclide-commons': 'workspace:*'
       event-kit: 2.2.0
       fb-watchman: 2.0.1
       log4js: 1.1.1
-      rxjs: 'npm:rxjs-compat@6.3.3'
+      rxjs-compat: ^6.3.3
   nuclide/nuclide-adb:
     dependencies:
       '@atom-ide-community/nuclide-commons': 'link:../nuclide-commons'
       '@atom-ide-community/nuclide-commons-atom': 'link:../nuclide-commons-atom'
       log4js: 1.1.1
       nullthrows: 1.1.1
-      rxjs: /rxjs-compat/6.3.3
+      rxjs-compat: 6.3.3
       shallowequal: 1.1.0
     specifiers:
       '@atom-ide-community/nuclide-commons': 'workspace:*'
       '@atom-ide-community/nuclide-commons-atom': 'workspace:*'
       log4js: 1.1.1
       nullthrows: 1.1.1
-      rxjs: 'npm:rxjs-compat@6.3.3'
+      rxjs-compat: ^6.3.3
       shallowequal: 1.1.0
   nuclide/nuclide-analytics:
     dependencies:
@@ -439,7 +439,7 @@ importers:
       mv: 2.1.1
       nullthrows: 1.1.1
       rimraf: 3.0.2
-      rxjs: /rxjs-compat/6.3.3
+      rxjs-compat: 6.3.3
       semver: 5.5.0
       shell-quote: 1.6.1
       temp: 0.9.1
@@ -471,7 +471,7 @@ importers:
       mv: 2.1.1
       nullthrows: 1.1.1
       rimraf: 3.0.2
-      rxjs: 'npm:rxjs-compat@6.3.3'
+      rxjs-compat: ^6.3.3
       semver: 5.5.0
       shell-quote: 1.6.1
       simple-text-buffer: 9.2.11
@@ -490,7 +490,7 @@ importers:
       lru-cache: 4.0.2
       nullthrows: 1.1.1
       redux-logger: 3.0.6
-      rxjs: /rxjs-compat/6.3.3
+      rxjs-compat: 6.3.3
       season: 6.0.2
       semver: 5.5.0
       shallowequal: 1.1.0
@@ -508,7 +508,7 @@ importers:
       lru-cache: 4.0.2
       nullthrows: 1.1.1
       redux-logger: 3.0.6
-      rxjs: 'npm:rxjs-compat@6.3.3'
+      rxjs-compat: ^6.3.3
       season: 6.0.2
       semver: 5.5.0
       shallowequal: 1.1.0
@@ -535,7 +535,7 @@ importers:
       react: 16.6.3
       react-dom: 16.6.3_react@16.6.3
       react-virtualized: 9.20.1_react-dom@16.6.3+react@16.6.3
-      rxjs: /rxjs-compat/6.3.3
+      rxjs-compat: 6.3.3
       semver: 5.5.0
       shallowequal: 1.1.0
       tabbable: 1.1.0
@@ -559,7 +559,7 @@ importers:
       react: 16.6.3
       react-dom: 16.6.3
       react-virtualized: 9.20.1
-      rxjs: 'npm:rxjs-compat@6.3.3'
+      rxjs-compat: ^6.3.3
       semver: 5.5.0
       shallowequal: 1.1.0
       tabbable: 1.1.0
@@ -575,7 +575,7 @@ importers:
       line-by-line: 0.1.6
       log4js: 1.1.1
       nullthrows: 1.1.1
-      rxjs: /rxjs-compat/6.3.3
+      rxjs-compat: 6.3.3
       v8-compile-cache: 1.1.0
       vscode-debugprotocol: 1.24.0
       yargs: 3.32.0
@@ -597,7 +597,7 @@ importers:
       line-by-line: 0.1.6
       log4js: 1.1.1
       nullthrows: 1.1.1
-      rxjs: 'npm:rxjs-compat@6.3.3'
+      rxjs-compat: ^6.3.3
       simple-text-buffer: 9.2.11
       v8-compile-cache: 1.1.0
       vscode-debugprotocol: 1.24.0
@@ -613,7 +613,7 @@ importers:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 16.6.3
-      rxjs: /rxjs-compat/6.3.3
+      rxjs-compat: 6.3.3
       uuid: 3.0.1
       vscode-debugprotocol: 1.24.0
     specifiers:
@@ -626,7 +626,7 @@ importers:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 16.6.3
-      rxjs: 'npm:rxjs-compat@6.3.3'
+      rxjs-compat: ^6.3.3
       uuid: 3.0.1
       vscode-debugprotocol: 1.24.0
   nuclide/nuclide-fuzzy-native:
@@ -696,13 +696,13 @@ importers:
       event-kit: 2.2.0
       fb-watchman: 2.0.1
       log4js: 1.1.1
-      rxjs: /rxjs-compat/6.3.3
+      rxjs-compat: 6.3.3
     specifiers:
       '@atom-ide-community/nuclide-commons': 'workspace:*'
       event-kit: 2.2.0
       fb-watchman: 2.0.1
       log4js: 1.1.1
-      rxjs: 'npm:rxjs-compat@6.3.3'
+      rxjs-compat: ^6.3.3
 lockfileVersion: 5.1
 packages:
   /@babel/cli/7.11.6_@babel+core@7.11.6:


### PR DESCRIPTION
This fixes rxjs. Nuclide used to use an alias for `rxjs-compat/bundles/...`, which was confusing and at first glance, I thought they just install rxjs-compat with rxjs name. This reverts that commit and uses the correct path of the library.

In the future, we will move to Rxjs itself which is tree-shakable.