### PR TITLE
feat: support providing adapterExecutable from the debugger provider (de-hardcode)

### DIFF
--- a/nuclide/nuclide-debugger-common/AutoGenLaunchAttachUiComponent.js
+++ b/nuclide/nuclide-debugger-common/AutoGenLaunchAttachUiComponent.js
@@ -515,7 +515,7 @@ export default class AutoGenLaunchAttachUiComponent extends React.Component<
       deviceAndProcessValues,
       selectSourcesValues,
     } = this.state;
-    const {launch, vsAdapterType, getProcessName} = config;
+    const {launch, vsAdapterType, getProcessName, adapterExecutable} = config;
 
     const stringValues = new Map();
     const stringArrayValues = new Map();
@@ -626,6 +626,7 @@ export default class AutoGenLaunchAttachUiComponent extends React.Component<
       targetUri,
       debugMode: launch ? 'launch' : 'attach',
       adapterType: vsAdapterType,
+      adapterExecutable,
       config: values,
       customControlButtons: [],
       processName: getProcessName(values),


### PR DESCRIPTION
This `adapterExecutable` can be provided by the debugger-providers.

Related to https://github.com/atom-ide-community/atom-ide-debugger/issues/2#issuecomment-711978619

See https://github.com/atom-ide-community/atom-ide-javascript/pull/5/commits/acd9a6c96173e94e7ae428fb838f32eea417251a